### PR TITLE
Fix profile width, use `fr` instead of `vw` units.

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -41,6 +41,7 @@
                         </h1>
                     </div>
                     <h4>@tommylong</h4>
+                </section>
     <div id="wrapper">
         <!-- <main class="bg-dark text-secondary px-4 py-5 text-center"> -->
 

--- a/styles/profile_styles.css
+++ b/styles/profile_styles.css
@@ -18,7 +18,7 @@ body {
 /*== Grid layout for profile page ==*/
 #wrapper {
     display: grid;
-    grid-template-columns: repeat(8, 12.25vw);
+    grid-template-columns: repeat(8, 1fr);
     grid-template-rows: repeat(20, 5vw);
 }
 


### PR DESCRIPTION
Now the profile page is no longer slightly-too-wide.